### PR TITLE
ci: fix broken ansible lint job

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible yamllint ansible-lint==5.0.1
+          pip3 install ansible yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   file:
     path: "{{ item }}"
     state: directory
+    mode: 'u+rw,g+r,o+r'
   with_items:
     - "{{ cni_bin_dir }}"
     - "{{ cni_conf_dir }}"


### PR DESCRIPTION
Unfreeze ansible-lint version: 5.0.1 -> 5.0.11 (latest)