### PR TITLE
style: use fqcn for ansible task plugins

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,4 +3,3 @@
 skip_list:
  - 'role-name'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
  - 'no-changed-when'  # Commands should not change things if nothing needs doing
- - 'fqcn-builtins'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,13 +4,13 @@
   become: true
   pre_tasks:
     - name: "Pre-task | Update apt-cache"
-      apt:
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 600
       when: "ansible_os_family == 'Debian'"
 
     - name: "Pre-task | Create required directories"
-      file:
+      ansible.builtin.file:
         mode: "u+rw,g+r,o+r"
         path: "{{ item }}"
         state: "directory"
@@ -19,5 +19,5 @@
 
   tasks:
     - name: "Include symplegma-cni"
-      include_role:
+      ansible.builtin.include_role:
         name: "symplegma-cni"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,5 +6,5 @@
   gather_facts: false
   tasks:
   - name: Example assertion
-    assert:
+    ansible.builtin.assert:
       that: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: CNI | Ensure CNI directories exist
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 'u+rw,g+r,o+r'
@@ -9,7 +9,7 @@
     - "{{ cni_conf_dir }}"
 
 - name: CNI | Download CNI plugins binaries
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ cni_plugins_release_url }}"
     dest: "{{ cni_bin_dir }}"
     remote_src: true


### PR DESCRIPTION
Another PR to use fqcn in project and make `ansible-lint` complain without it